### PR TITLE
Fix for access-after-free bug

### DIFF
--- a/include/hokuyoaist/hokuyo_errors.h
+++ b/include/hokuyoaist/hokuyo_errors.h
@@ -80,15 +80,14 @@ class HOKUYOAIST_EXPORT BaseError : public std::exception
         virtual char const* error_type() const throw()
             { return error_type_; }
 
-        virtual const char* what() throw();
+        virtual std::ostream& format (std::ostream&) const throw ();
+
+        std::string what() throw();
 
     protected:
         /** Description code for use with the error string table. */
         unsigned int desc_code_;
 
-        /** Formatted description of the error. */
-        std::stringstream ss;
-        std::string ss_str;
         /** String representation of the error. */
         char error_type_[32];
 }; //class BaseError
@@ -171,7 +170,7 @@ class HOKUYOAIST_EXPORT BaudrateError: public RuntimeError
         unsigned int baud() const throw()
             { return baud_; }
 
-        const char* what() throw();
+        std::ostream& format (std::ostream&) const throw ();
 
     protected:
         /** Baud rate that caused the error. */
@@ -369,7 +368,7 @@ class HOKUYOAIST_EXPORT ChecksumError: public ProtocolError
         virtual int calculated() const throw()
             { return calculated_; }
 
-        const char* what() throw();
+        std::ostream& format (std::ostream&) const throw ();
 
     protected:
         /** Expected checksum value. */
@@ -412,7 +411,7 @@ class HOKUYOAIST_EXPORT UnknownLineError: public ProtocolError
         virtual char const* const line() const throw()
             { return line_; }
 
-        const char* what() throw();
+        std::ostream& format (std::ostream&) const throw ();
 
     protected:
         /** The mystery line. */
@@ -437,7 +436,7 @@ class HOKUYOAIST_EXPORT ParseError: public ProtocolError
         virtual char const* const type() const throw()
             { return type_; }
 
-        const char* what() throw();
+        std::ostream& format (std::ostream&) const throw ();
 
     protected:
         /** The bad line. */
@@ -488,7 +487,7 @@ class HOKUYOAIST_EXPORT ResponseError: public ProtocolError
         virtual char const* const cmd_code() const throw()
             { return cmd_; }
 
-        const char* what() throw();
+        std::ostream& format (std::ostream&) const throw ();
 
     protected:
         /** Error code as defined in SCIP2 (two bytes). */
@@ -523,7 +522,7 @@ class HOKUYOAIST_EXPORT Scip1ResponseError: public ProtocolError
         virtual char cmd_code() const throw()
             { return cmd_; }
 
-        const char* what() throw();
+        std::ostream& format (std::ostream&) const throw ();
 
     protected:
         /** Error code as defined in SCIP2 (two bytes). */
@@ -564,7 +563,7 @@ class HOKUYOAIST_EXPORT CommandEchoError: public ProtocolError
         virtual char const* const cmd_echo() const throw()
             { return echo_; }
 
-        const char* what() throw();
+        std::ostream& format (std::ostream&) const throw ();
 
     protected:
         /** Command that triggered the error, from SCIP2 (two bytes). */
@@ -597,7 +596,7 @@ class HOKUYOAIST_EXPORT ParamEchoError: public ProtocolError
         virtual char const* const cmd_code() const throw()
             { return cmd_; }
 
-        const char* what() throw();
+        std::ostream& format (std::ostream&) const throw ();
 
     protected:
         /** Command that triggered the error, from SCIP2 (two bytes). */
@@ -628,7 +627,7 @@ class HOKUYOAIST_EXPORT InsufficientBytesError: public ProtocolError
         virtual int line_length() const throw()
             { return line_length_; }
 
-        const char* what() throw();
+        std::ostream& format (std::ostream&) const throw ();
 
     protected:
         /** Number of bytes available. */
@@ -661,7 +660,7 @@ class HOKUYOAIST_EXPORT LineLengthError: public ProtocolError
         virtual int expected() const throw()
             { return expected_; }
 
-        const char* what() throw();
+        std::ostream& format (std::ostream&) const throw ();
 
     protected:
         /** The received line length. */
@@ -669,6 +668,9 @@ class HOKUYOAIST_EXPORT LineLengthError: public ProtocolError
         /** The expected line length. */
         int expected_;
 }; // class LineLengthError
+
+/* Dispatches to the appropriate format() method.  */
+extern std::ostream& operator << (std::ostream& ostr, const BaseError& e);
 
 }; // namespace hokuyoaist
 

--- a/include/hokuyoaist/hokuyo_errors.h
+++ b/include/hokuyoaist/hokuyo_errors.h
@@ -88,6 +88,7 @@ class HOKUYOAIST_EXPORT BaseError : public std::exception
 
         /** Formatted description of the error. */
         std::stringstream ss;
+        std::string ss_str;
         /** String representation of the error. */
         char error_type_[32];
 }; //class BaseError

--- a/python/hokuyo_aist.cpp
+++ b/python/hokuyo_aist.cpp
@@ -44,7 +44,7 @@ class BaseErrorWrap
             return BaseError::error_type();
         }
 
-        const char* what() throw()
+        std::string what() throw()
         {
             if (boost::python::override f = get_override("what"))
             {
@@ -52,7 +52,7 @@ class BaseErrorWrap
             }
             return BaseError::what();
         }
-        const char* default_what() throw()
+        std::string default_what() throw()
         {
             return BaseError::what();
         }

--- a/src/hokuyo_errors.cpp
+++ b/src/hokuyo_errors.cpp
@@ -377,30 +377,30 @@ BaseError::BaseError(BaseError const& rhs)
 }
 
 
-const char* BaseError::what() throw()
+std::string BaseError::what () throw ()
 {
-    ss << error_type_ << " (" << desc_code_ << "): " <<
+    std::stringstream ss;
+    format (ss);
+    return ss.str ();
+}
+
+std::ostream& BaseError::format(std::ostream& ostr) const throw()
+{
+    return ostr << error_type_ << " (" << desc_code_ << "): " <<
         desc_code_to_string(desc_code_);
-    ss_str = ss.str();
-    return ss_str.c_str();;
 }
 
 
-const char* BaudrateError::what() throw()
+std::ostream& BaudrateError::format(std::ostream& ostr) const throw()
 {
-    RuntimeError::what();
-    ss << baud_;
-    ss_str = ss.str();
-    return ss_str.c_str();;
+    return RuntimeError::format (ostr) << baud_;
 }
 
 
-const char* ChecksumError::what() throw()
+std::ostream& ChecksumError::format(std::ostream& ostr) const throw()
 {
-    ProtocolError::what();
-    ss << "expected " << expected_ << ", calculated " << calculated_;
-    ss_str = ss.str();
-    return ss_str.c_str();;
+    return ProtocolError::format (ostr)
+        << "expected " << expected_ << ", calculated " << calculated_;
 }
 
 
@@ -418,12 +418,9 @@ UnknownLineError::UnknownLineError(UnknownLineError const& rhs)
 }
 
 
-const char* UnknownLineError::what() throw()
+std::ostream& UnknownLineError::format(std::ostream& ostr) const throw()
 {
-    ProtocolError::what();
-    ss << line_;
-    ss_str = ss.str();
-    return ss_str.c_str();;
+    return ProtocolError::format(ostr) << line_;
 }
 
 
@@ -443,72 +440,62 @@ ParseError::ParseError(ParseError const& rhs)
 }
 
 
-const char* ParseError::what() throw()
+std::ostream& ParseError::format(std::ostream& ostr) const throw()
 {
-    ProtocolError::what();
-    ss << "Line type: " << type_ << ". Line: " << line_;
-    ss_str = ss.str();
-    return ss_str.c_str();;
+    return ProtocolError::format(ostr)
+        << "Line type: " << type_ << ". Line: " << line_;
 }
 
 
-const char* ResponseError::what() throw()
+std::ostream& ResponseError::format(std::ostream& ostr) const throw()
 {
-    ProtocolError::what();
-    ss << " Command: " << cmd_[0] << cmd_[1];
-    ss << " Error : (" << error_[0] << error_[1] << ") " <<
-        scip2_error_to_string(error_, cmd_);
-    ss_str = ss.str();
-    return ss_str.c_str();;
+    return ProtocolError::format(ostr)
+        << " Command: " << cmd_[0] << cmd_[1]
+        << " Error : (" << error_[0] << error_[1]
+        << ") " << scip2_error_to_string(error_, cmd_);
 }
 
 
-const char* Scip1ResponseError::what() throw()
+std::ostream& Scip1ResponseError::format(std::ostream& ostr) const throw()
 {
-    ProtocolError::what();
-    ss << " Command: " << cmd_;
-    ss << " Error : " << error_;
-    ss_str = ss.str();
-    return ss_str.c_str();;
+    return ProtocolError::format(ostr)
+        << " Command: " << cmd_ << " Error : " << error_;
 }
 
 
-const char* CommandEchoError::what() throw()
+std::ostream& CommandEchoError::format(std::ostream& ostr) const throw()
 {
-    ProtocolError::what();
-    ss << " Command: " << cmd_[0] << cmd_[1];
-    ss << " Received echo: " << echo_[0] << echo_[1];
-    ss_str = ss.str();
-    return ss_str.c_str();;
+    return ProtocolError::format(ostr)
+        << " Command: " << cmd_[0] << cmd_[1]
+        << " Received echo: " << echo_[0] << echo_[1];
 }
 
 
-const char* ParamEchoError::what() throw()
+std::ostream& ParamEchoError::format(std::ostream& ostr) const throw()
 {
-    ProtocolError::what();
-    ss << " Command: " << cmd_[0] << cmd_[1];
-    ss_str = ss.str();
-    return ss_str.c_str();;
+    return ProtocolError::format(ostr)
+        << " Command: " << cmd_[0] << cmd_[1];
 }
 
 
-const char* InsufficientBytesError::what() throw()
+std::ostream& InsufficientBytesError::format(std::ostream& ostr) const throw()
 {
-    ProtocolError::what();
-    ss << " Number of bytes: " << num_;
-    ss << " Line length: " << line_length_;
-    ss_str = ss.str();
-    return ss_str.c_str();;
+    return ProtocolError::format(ostr)
+        << " Number of bytes: " << num_
+        << " Line length: " << line_length_;
 }
 
 
-const char* LineLengthError::what() throw()
+std::ostream& LineLengthError::format(std::ostream& ostr) const throw()
 {
-    ProtocolError::what();
-    ss << " Received length: " << length_;
-    ss << " Expected line length: " << expected_;
-    ss_str = ss.str();
-    return ss_str.c_str();;
+    return ProtocolError::format(ostr)
+        << " Received length: " << length_
+        << " Expected line length: " << expected_;
+}
+
+std::ostream& operator << (std::ostream& ostr, const BaseError& e)
+{
+    return e.format (ostr);
 }
 
 }; // namespace hokuyoaist

--- a/src/hokuyo_errors.cpp
+++ b/src/hokuyo_errors.cpp
@@ -381,7 +381,8 @@ const char* BaseError::what() throw()
 {
     ss << error_type_ << " (" << desc_code_ << "): " <<
         desc_code_to_string(desc_code_);
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 
@@ -389,7 +390,8 @@ const char* BaudrateError::what() throw()
 {
     RuntimeError::what();
     ss << baud_;
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 
@@ -397,7 +399,8 @@ const char* ChecksumError::what() throw()
 {
     ProtocolError::what();
     ss << "expected " << expected_ << ", calculated " << calculated_;
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 
@@ -419,7 +422,8 @@ const char* UnknownLineError::what() throw()
 {
     ProtocolError::what();
     ss << line_;
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 
@@ -443,7 +447,8 @@ const char* ParseError::what() throw()
 {
     ProtocolError::what();
     ss << "Line type: " << type_ << ". Line: " << line_;
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 
@@ -453,7 +458,8 @@ const char* ResponseError::what() throw()
     ss << " Command: " << cmd_[0] << cmd_[1];
     ss << " Error : (" << error_[0] << error_[1] << ") " <<
         scip2_error_to_string(error_, cmd_);
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 
@@ -462,7 +468,8 @@ const char* Scip1ResponseError::what() throw()
     ProtocolError::what();
     ss << " Command: " << cmd_;
     ss << " Error : " << error_;
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 
@@ -471,7 +478,8 @@ const char* CommandEchoError::what() throw()
     ProtocolError::what();
     ss << " Command: " << cmd_[0] << cmd_[1];
     ss << " Received echo: " << echo_[0] << echo_[1];
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 
@@ -479,7 +487,8 @@ const char* ParamEchoError::what() throw()
 {
     ProtocolError::what();
     ss << " Command: " << cmd_[0] << cmd_[1];
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 
@@ -488,7 +497,8 @@ const char* InsufficientBytesError::what() throw()
     ProtocolError::what();
     ss << " Number of bytes: " << num_;
     ss << " Line length: " << line_length_;
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 
@@ -497,7 +507,8 @@ const char* LineLengthError::what() throw()
     ProtocolError::what();
     ss << " Received length: " << length_;
     ss << " Expected line length: " << expected_;
-    return ss.str().c_str();
+    ss_str = ss.str();
+    return ss_str.c_str();;
 }
 
 }; // namespace hokuyoaist


### PR DESCRIPTION
先週の最後に見つけたバグのquick & dirty fixです。コミットメッセージにもあるように、長期的には文字列を返すインターフェースから出力先を受け取るインターフェースに変えることが望ましいと思います。

手元で走らせる環境がないので、**一瞬たりともテストしていません**。ご注意下さい。

追記: "Longer-term fix" の方はもっとまともな修正をしていますが、後方互換性が失われています。殆どのクライアントコードは変更無しでコンパイルできると思いますが、エラーが出ることもあるかも知れません。
